### PR TITLE
[#125] Add READMEs pointing to partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This repository provides Reference Designs and Deployment Guides for Tanzu produ
 
 The current collection of published Reference Designs may be found in our [Table of Contents](./src/toc.md)
 
+> **NOTE**: An appendix containing additional helpful documents such as
+> troubleshooting guides and recommended labs can be found [here](src/partials)
+
 ## Contributing
 
 The tanzu-validated-solutions project team welcomes contributions from the community. Before you start working with tanzu-validated-solutions, please

--- a/src/partials/README.md
+++ b/src/partials/README.md
@@ -1,0 +1,9 @@
+# Partials
+
+This folder contains additional information that might help you while
+implementing these Reference Architectures.
+
+- [Allow TMC-created service accounts to create `Pod`s](src/partials/tmc-service-account-pods.md)
+- [Tanzu Kubernetes Grid Backup Operations with Velero vSphere Plugin](src/partials/tkg-velero-vsphere-plugin.md)
+- [Simulating TKO on vSphere with Tanzu networking utilizing Vyatta](src/partials/vyatta.md)
+- [The Supervisor Cluster fails to come online](src/partials/troubleshoot-supervisor.md)


### PR DESCRIPTION
There doesn't seem to be anything that refers back to the documentation in partials, making discoverability difficult. This PR fixes that.